### PR TITLE
KAN-16: Species Modal Close Button & "Brand or Model" modal close

### DIFF
--- a/fish-select.js
+++ b/fish-select.js
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
-import { View, Text, TextInput, Modal,FlatList, Image } from 'react-native';
+import { View, Text, TextInput, Modal,FlatList, Image, TouchableOpacity } from 'react-native';
 import FishSelectItem from "./fish-select-item";
 import { loadTranslations } from './global/localization';
-const FishSelect = ({ visible, selectedFish, onSelectFish }) => {
+import { btn_style, flex_style, margin_styles, text_style } from './global/global-styles';
+const FishSelect = ({ visible, setVisible, selectedFish, onSelectFish }) => {
   const [searchText, setSearchText] = useState('');
 
   const fishData = [
@@ -46,6 +47,14 @@ const FishSelect = ({ visible, selectedFish, onSelectFish }) => {
           keyExtractor={(item) => item.id.toString()}
           ItemSeparatorComponent={() => <View style={{ height: 10 }} />}
         />
+        <TouchableOpacity
+          onPress={() => { setVisible(false) }}
+          style={[btn_style.button, btn_style.round, btn_style.buttonReversed, margin_styles.top_md, flex_style.flex]}
+        >
+          <Text style={[text_style.primaryColor,
+          text_style.bold,
+          text_style.alignCenter]}>{loadTranslations('close')}</Text>
+        </TouchableOpacity>
       </View>
     </Modal>
   );

--- a/global/supportedLanguages.json
+++ b/global/supportedLanguages.json
@@ -1,5 +1,6 @@
 {
     "en": {
+        "close":"Close",
         "bioPressure": "Biometric Pressure",
         "brand": "Lure brand",
         "brandOrModel": "Brand Or Model",
@@ -182,6 +183,7 @@
         
     },
     "fr": {
+        "close":"Fermer",
         "bioPressure": "Pression biométrique",
         "brand": "Marque de leurre",
         "brandOrModel": "Brand Ou Model",

--- a/screens/ConditionsForm.js
+++ b/screens/ConditionsForm.js
@@ -361,7 +361,7 @@ const ConditionsForm = ({ navigation })  => {
         </Tooltip>
         )}
       </View>
-        <FishSelect visible={speciesModalVisible} selectedFish={species} onSelectFish={onSelectFish}></FishSelect>
+        <FishSelect visible={speciesModalVisible} setVisible={setSpeciesModalVisible} selectedFish={species} onSelectFish={onSelectFish}></FishSelect>
         <View style={[flex_style.width100, margin_styles.bottom_md]}>
           {!species?.image ? 
             <TouchableOpacity

--- a/screens/LuresForm.js
+++ b/screens/LuresForm.js
@@ -159,6 +159,14 @@ export default function LuresForm({ navigation }) {
                   setCurrentTutorial={setCurrentTutorial}
                   />
                     <DropdownWithModal noItemsPlaceholder={"noLures"} parentSetModalVisible={setBrandAndModalVisible} setSelectedItem={item => onBrandAndModelSelect(item)} dataset={brandAndModelDataset} onChangeText={ text => onChangeText(text)}></DropdownWithModal>
+                <TouchableOpacity
+                  onPress={() => { setBrandAndModalVisible(false) }}
+                  style={[btn_style.button, btn_style.round, btn_style.buttonReversed, margin_styles.top_md, flex_style.flex]}
+                >
+                  <Text style={[text_style.primaryColor,
+                  text_style.bold,
+                  text_style.alignCenter]}>{loadTranslations('close')}</Text>
+                </TouchableOpacity>
                   </View>
                 </Modal>
             </View>


### PR DESCRIPTION
This MR creates a close button in the species modal so it  can be closed without picking a new species.

Since the 'brand or model'  popup had a similar problem to the species modal (unable to exit unless they pick a new option), I applied the button over there as well.

Both modals can now be exited by pressing the "Close" button.

Let me know if you would like the position/styling of the button to be different.

![](https://cdn.discordapp.com/attachments/1223039100781727859/1235963789355126795/Screenshot_20240503_103445_Expo_Go.jpg?ex=6636487a&is=6634f6fa&hm=4b492b579f618ffd4f7510d18f25429bd4089cd70d559d0e2deba619ccda32b7&)
![](https://cdn.discordapp.com/attachments/1223039100781727859/1235963789749256233/Screenshot_20240503_103556_Expo_Go.jpg?ex=6636487a&is=6634f6fa&hm=dca85269fe74f38287fe5b41ecb83b3d50e58184c0933e1c7527c62a497bdb0f&)