### PR TITLE
KAN-18: Fix 'VirtualizedList' error on DropdownWithModal

### DIFF
--- a/components/autocomplete.js
+++ b/components/autocomplete.js
@@ -68,7 +68,6 @@ const DropdownWithModal = ({ dataset, onChangeText, placeholder, setSelectedItem
   };
 
   const renderItem = ({ item }) => {
-    console.log(item);
     return (
       <Item
       item={item}

--- a/components/autocomplete.js
+++ b/components/autocomplete.js
@@ -77,18 +77,6 @@ const DropdownWithModal = ({ dataset, onChangeText, placeholder, setSelectedItem
     );
   }
 
-  const renderSimpleItem = (item) => {
-    console.log(item);
-    return (
-      <Item
-      item={item}
-      onPress={() => handleSelectItem(item)}
-    />
-    );
-  }
-
-  
-
   return (
       <View style={[styles.container, {justifyContent: 'space-between'}]}>
         <TextInput
@@ -101,7 +89,7 @@ const DropdownWithModal = ({ dataset, onChangeText, placeholder, setSelectedItem
               />
       {!!inputValue && (
         simple? 
-        items.map((item)=>{return renderSimpleItem(item)})
+        items.map((item)=>{return renderItem({item})})
         :
         <FlatList
         nestedScrollEnabled={true}
@@ -110,7 +98,6 @@ const DropdownWithModal = ({ dataset, onChangeText, placeholder, setSelectedItem
         renderItem={renderItem}
         keyExtractor={(item, index) => index}
       />
-        
       )}
       {reactIfView(!!inputValue && items?.length < 1,
         <Text style={[text_style.alignCenter, text_style.xs, text_style.fontColorRed]}>{loadTranslations(noItemsPlaceholder)}</Text>

--- a/components/autocomplete.js
+++ b/components/autocomplete.js
@@ -25,7 +25,7 @@ const Item = ({item, onPress}) => (
 );
 
 
-const DropdownWithModal = ({ dataset, onChangeText, placeholder, setSelectedItem, parentSetModalVisible, noItemsPlaceholder, showCancelButton }) => {
+const DropdownWithModal = ({ dataset, onChangeText, placeholder, setSelectedItem, parentSetModalVisible, noItemsPlaceholder, showCancelButton, simple }) => {
   const [inputValue, setInputValue] = useState('');
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [items, setItems] = useState([]);
@@ -68,6 +68,7 @@ const DropdownWithModal = ({ dataset, onChangeText, placeholder, setSelectedItem
   };
 
   const renderItem = ({ item }) => {
+    console.log(item);
     return (
       <Item
       item={item}
@@ -75,6 +76,18 @@ const DropdownWithModal = ({ dataset, onChangeText, placeholder, setSelectedItem
     />
     );
   }
+
+  const renderSimpleItem = (item) => {
+    console.log(item);
+    return (
+      <Item
+      item={item}
+      onPress={() => handleSelectItem(item)}
+    />
+    );
+  }
+
+  
 
   return (
       <View style={[styles.container, {justifyContent: 'space-between'}]}>
@@ -87,6 +100,9 @@ const DropdownWithModal = ({ dataset, onChangeText, placeholder, setSelectedItem
           onChangeText={onType}
               />
       {!!inputValue && (
+        simple? 
+        items.map((item)=>{return renderSimpleItem(item)})
+        :
         <FlatList
         nestedScrollEnabled={true}
         style={styles.modalContainer}
@@ -94,6 +110,7 @@ const DropdownWithModal = ({ dataset, onChangeText, placeholder, setSelectedItem
         renderItem={renderItem}
         keyExtractor={(item, index) => index}
       />
+        
       )}
       {reactIfView(!!inputValue && items?.length < 1,
         <Text style={[text_style.alignCenter, text_style.xs, text_style.fontColorRed]}>{loadTranslations(noItemsPlaceholder)}</Text>

--- a/screens/ConditionsForm.js
+++ b/screens/ConditionsForm.js
@@ -271,6 +271,7 @@ const ConditionsForm = ({ navigation })  => {
         </View>
 
       <DropdownWithModal
+            simple={true}
             showCancelButton={false}
             placeholder={locationName}
             onChangeText={getAutofilledLocations}
@@ -278,6 +279,7 @@ const ConditionsForm = ({ navigation })  => {
             dataset={autofilledLocations}
             parentSetModalVisible={setModalVisible}
             setSelectedItem={onLocationSelected}
+            
       />
       <View style={[flex_style.flex, flex_style.width100]}>
         <TutorialTooltip conditions={currentTutorial == 'structure'} style={tutorial_styles.multiLine} 
@@ -289,6 +291,7 @@ const ConditionsForm = ({ navigation })  => {
         </View>
       </View>
         <DropdownWithModal
+            simple={true}
             showCancelButton={false}
             onChangeText={event => setStructureInput(event)}
             noItemsPlaceholder='noStructure'


### PR DESCRIPTION
The DropdownWithModal component was causing issues when placed in a scrollview as it had a 'FlatList' in it, which doesn't mix well with scrollview.

My solution was to create an optional 'simple' parameter.
By toggling this on as a prop, the DropdownWithModal would not use Flatlist to render, but just doing a map to change the item array to a React component array. This won't have a hit performance as we would ideally only use this for lists that have around 5 or so elements (not much).

If you want to use the DropdownWithModal with a lot of elements and keep the scrolling on, like in the lure 'Brand Or Modal' search, you can simply either set 'simple' to false, or just don't declare it. That would make the component work exactly as it was before. 