### PR TITLE
Remove all false params in all getAuthToken

### DIFF
--- a/add-lure-modal.js
+++ b/add-lure-modal.js
@@ -119,7 +119,7 @@ const AddLureModal = (props) => {
     }
 
     const url = environment.host + '/api/custom/addLure'
-    const token = await getAuthToken(false)
+    const token = await getAuthToken();
     const response = await fetch(url, {
       method: 'POST',
       body: formData,

--- a/authentication/auth.js
+++ b/authentication/auth.js
@@ -16,7 +16,7 @@ export default function Authentication(props) {
   }
   useEffect(() => {
     async function checkAuthentication() {
-      setAuthenticatedRef(getAuthToken(false))
+      setAuthenticatedRef(getAuthToken())
     }
     if (!authenticated) {
       checkAuthentication()

--- a/global/utils/add-to-my-lures.util.js
+++ b/global/utils/add-to-my-lures.util.js
@@ -3,7 +3,7 @@ import { getAuthToken } from "./auth.utils";
 export async function addToMyLures(lureID, onPass, onFail, onFailDuplicate) {
     try {
         const url = environment.host + '/api/add-to-user-lures'
-        const token = await getAuthToken(false)
+        const token = await getAuthToken()
         const response = await fetch(url, {
             method: 'POST',
             body: JSON.stringify({ lureOption: lureID }),

--- a/navigation.js
+++ b/navigation.js
@@ -41,7 +41,7 @@ export default function Navigation() {
 
   useEffect(() => {
     async function checkAuthentication() {
-      const token = await getAuthToken(false);
+      const token = await getAuthToken();
       if (token) {
         setAuthenticated(true);
       }

--- a/screens/Profile.js
+++ b/screens/Profile.js
@@ -34,7 +34,7 @@ export default function Profile({ navigation }) {
 
   useEffect(() => {
     async function getData(){
-      const t = await getAuthToken(false);
+      const t = await getAuthToken();
       setToken(t);
     }
     getData();


### PR DESCRIPTION
All the false parameters in getAuthToken are removed (which defaults the function's navigateIfNotAuth parameter to true). This makes it so it forces the user back to the login screen if they aren't logged in.